### PR TITLE
Automatically extract owner/name of repo

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,16 @@
 
 # These variables are used for controlling how the image gets tagged when it's built, and they can be overridden when
 # the call to the make command is made
-IMAGE_NAME = ghcr.io/jrwagz/docker-image-example-template
+
+# These variables are to easily extract the GitHub owner/name of the repo, using just the remote.origin.url
+REMOTE_URL := $(shell git config --get remote.origin.url)
+# this parsing of the owner is a bit complex, but it should work for both git and https remotes for github like follows
+# https://github.com/jrwagz/docker-image-example-template.git
+# git@github.com:jrwagz/docker-image-example-template.git
+REPO_OWNER := $(shell echo $(REMOTE_URL) | sed -E -e "s|.*[:/]([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)\.git|\1|")
+REPO_NAME  := $(shell basename $(REMOTE_URL) .git)
+REPO_FULL_NAME := $(REPO_OWNER)/$(REPO_NAME)
+IMAGE_NAME := ghcr.io/$(REPO_FULL_NAME)
 
 # Here we default to an image tag that makes it obvious that it was a local build, and that it isn't coming from CI
 IMAGE_TAG:=$(shell whoami)-$(shell git describe --always)-dirty
@@ -12,6 +21,8 @@ DOCKERFILE_LINT_IMAGE:=ghcr.io/hadolint/hadolint:v2.12.0
 DIVE_IMAGE:=ghcr.io/wagoodman/dive:v0.13.1
 YAML_LINT_IMAGE:=pipelinecomponents/yamllint:0.34.0
 
+# Some of the docker run tasks are better when -it is provided locally, but fail in CI with that value, so here we
+# ensure that the appropriate version is available based on where the commands are being executed
 IS_TTY := $(shell [ -t 0 ] && echo yes || echo no)
 ifeq ($(IS_TTY),yes)
 TTY_ARGS := "-it"
@@ -29,7 +40,7 @@ build:
       -w "$(PWD)" \
 	  -e CI=true \
       $(DIVE_IMAGE) $(IMAGE_NAME):$(IMAGE_TAG)
-	@echo SUCCESS $(FULL_NAME):$(IMAGE_TAG) is built and has been scanned by dive
+	@echo SUCCESS $(IMAGE_NAME):$(IMAGE_TAG) is built and has been scanned by dive
 
 MD_FILES:=$(shell find . -name "*.md")
 .PHONY: lint_markdown


### PR DESCRIPTION
This change makes is so that the makefile automatically determines the repo owner and name on GitHub from the remote url.  So that this can be forked and used as a template without having this value hard coded in the makefile.